### PR TITLE
Also support for `<local-source-name>` productions to `UnqualifiedName::starts_with`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1827,9 +1827,7 @@ where
             }
             UnqualifiedName::CtorDtor(ref ctor_dtor) => ctor_dtor.demangle(ctx, stack),
             UnqualifiedName::Source(ref name) |
-            UnqualifiedName::LocalSourceName(ref name, ..) => {
-                name.demangle(ctx, stack)
-            }
+            UnqualifiedName::LocalSourceName(ref name, ..) => name.demangle(ctx, stack),
             UnqualifiedName::UnnamedType(ref unnamed) => unnamed.demangle(ctx, stack),
             UnqualifiedName::ABITag(ref tagged) => tagged.demangle(ctx, stack),
             UnqualifiedName::ClosureType(ref closure) => closure.demangle(ctx, stack),
@@ -1840,9 +1838,10 @@ where
 impl UnqualifiedName {
     #[inline]
     fn starts_with(byte: u8, input: &IndexStr) -> bool {
-        OperatorName::starts_with(byte) || CtorDtorName::starts_with(byte) ||
-            SourceName::starts_with(byte) || UnnamedTypeName::starts_with(byte) ||
-            TaggedName::starts_with(byte) || ClosureTypeName::starts_with(byte, input)
+        byte == b'L' || OperatorName::starts_with(byte) || CtorDtorName::starts_with(byte) ||
+            SourceName::starts_with(byte) ||
+            UnnamedTypeName::starts_with(byte) || TaggedName::starts_with(byte) ||
+            ClosureTypeName::starts_with(byte, input)
     }
 
     fn accepts_double_colon(&self) -> bool {

--- a/tests/libxul.rs
+++ b/tests/libxul.rs
@@ -8,8 +8,8 @@ use std::process;
 const NUMBER_OF_LIBXUL_SYMBOLS: usize = 274346;
 
 // These counts should only go up!
-const NUMBER_OF_LIBXUL_SYMBOLS_THAT_PARSE: usize = 239352;
-const NUMBER_OF_LIBXUL_SYMBOLS_THAT_DEMANGLE: usize = 239352;
+const NUMBER_OF_LIBXUL_SYMBOLS_THAT_PARSE: usize = 274083;
+const NUMBER_OF_LIBXUL_SYMBOLS_THAT_DEMANGLE: usize = 274083;
 
 fn get_cppfilt() -> &'static str {
     if cfg!(not(target_os = "macos")) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -162,6 +162,8 @@ demangles!(
     "reference temporary #0 for MozLangGroups"
 );
 
+demangles!(_ZN11InstrumentsL8gSessionE, "Instruments::gSession");
+
 // Test cases found via differential testing against `c++filt` with `cargo-fuzz`
 // and `libFuzzer`.
 


### PR DESCRIPTION
Down to just under 350 symbols in libxul that don't parse and demangle (although only about 72% match libiberty's demangling).

cc @khuey 