### PR TITLE
Format `bool` literals as `true` or `false` when possible

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -96,7 +96,7 @@ fn test_afl_seed_{}() {{
 // Ratcheting number that is increased as more libiberty tests start
 // passing. Once they are all passing, this can be removed and we can enable all
 // of them by default.
-const LIBIBERTY_TEST_THRESHOLD: usize = 70;
+const LIBIBERTY_TEST_THRESHOLD: usize = 71;
 
 /// Read `tests/libiberty-demangle-expected`, parse its input mangled symbols,
 /// and expected output demangled symbols, and generate test cases for them.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -5352,6 +5352,26 @@ where
         match *self {
             ExprPrimary::External(ref name) => name.demangle(ctx, stack),
             ExprPrimary::Literal(
+                TypeHandle::Builtin(BuiltinType::Standard(StandardBuiltinType::Bool)),
+                start,
+                end,
+            ) => {
+                match &ctx.input[start..end] {
+                    b"0" => {
+                        write!(ctx, "false")?;
+                        Ok(())
+                    }
+                    b"1" => {
+                        write!(ctx, "true")?;
+                        Ok(())
+                    }
+                    otherwise => {
+                        write!(ctx, "(bool)")?;
+                        ctx.write_all(otherwise)
+                    }
+                }
+            }
+            ExprPrimary::Literal(
                 TypeHandle::Builtin(BuiltinType::Standard(StandardBuiltinType::Nullptr)),
                 _,
                 _,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -165,6 +165,11 @@ demangles!(
 demangles!(_ZN11InstrumentsL8gSessionE, "Instruments::gSession");
 demangles!(_ZTWN2js10TlsContextE, "TLS wrapper function for js::TlsContext");
 
+demangles!(_Z3fooILb0EEvi, "void foo<false>(int)");
+demangles!(_Z3fooILb1EEvi, "void foo<true>(int)");
+demangles!(_Z3fooILb2EEvi, "void foo<(bool)2>(int)");
+demangles!(_Z3fooILb999999EEvi, "void foo<(bool)999999>(int)");
+
 // Test cases found via differential testing against `c++filt` with `cargo-fuzz`
 // and `libFuzzer`.
 


### PR DESCRIPTION
And as casts with invalid `bool` values.