### PR TITLE
Constructor and destructor names

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -96,7 +96,7 @@ fn test_afl_seed_{}() {{
 // Ratcheting number that is increased as more libiberty tests start
 // passing. Once they are all passing, this can be removed and we can enable all
 // of them by default.
-const LIBIBERTY_TEST_THRESHOLD: usize = 83;
+const LIBIBERTY_TEST_THRESHOLD: usize = 85;
 
 /// Read `tests/libiberty-demangle-expected`, parse its input mangled symbols,
 /// and expected output demangled symbols, and generate test cases for them.

--- a/build.rs
+++ b/build.rs
@@ -15,9 +15,8 @@ fn get_crate_dir() -> io::Result<path::PathBuf> {
 }
 
 fn get_out_dir() -> io::Result<path::PathBuf> {
-    Ok(path::PathBuf::from(env::var("OUT_DIR").map_err(|_| {
-        io::Error::new(io::ErrorKind::Other, "no OUT_DIR")
-    })?))
+    Ok(path::PathBuf::from(env::var("OUT_DIR")
+        .map_err(|_| io::Error::new(io::ErrorKind::Other, "no OUT_DIR"))?))
 }
 
 fn get_crate_test_path(file_name: &str) -> io::Result<path::PathBuf> {
@@ -178,9 +177,9 @@ use std::fmt::Write;
         }
 
         // Skip tests for unsupported languages or options.
-        if options.find("--format=gnu-v3").is_none() || options.find("--is-v3-ctor").is_some() ||
-            options.find("--is-v3-dtor").is_some() ||
-            options.find("--ret-postfix").is_some()
+        if options.find("--format=gnu-v3").is_none() || options.find("--is-v3-ctor").is_some()
+            || options.find("--is-v3-dtor").is_some()
+            || options.find("--ret-postfix").is_some()
         {
             continue;
         }
@@ -264,11 +263,9 @@ fn test_libiberty_demangle_{}_() {{
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    generate_sanity_tests_from_afl_seeds().expect(
-        "should generate sanity tests from AFL.rs seed test cases",
-    );
+    generate_sanity_tests_from_afl_seeds()
+        .expect("should generate sanity tests from AFL.rs seed test cases");
 
-    generate_compatibility_tests_from_libiberty().expect(
-        "should generate compatibility tests from tests/libiberty-demangle-expected",
-    );
+    generate_compatibility_tests_from_libiberty()
+        .expect("should generate compatibility tests from tests/libiberty-demangle-expected");
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -245,11 +245,11 @@ trait GetTemplateArgs {
 /// This trait is implemented by anything that can potentially resolve arguments
 /// for us.
 trait ArgScope<'me, 'ctx>: fmt::Debug {
-    /// Get the current scope's `idx`th template argument.
-    fn get_template_arg(&'me self, idx: usize) -> Result<&'ctx TemplateArg>;
+    /// Get the current scope's `index`th template argument.
+    fn get_template_arg(&'me self, index: usize) -> Result<&'ctx TemplateArg>;
 
-    /// Get the current scope's `idx`th function argument's type.
-    fn get_function_arg(&'me self, idx: usize) -> Result<&'ctx Type>;
+    /// Get the current scope's `index`th function argument's type.
+    fn get_function_arg(&'me self, index: usize) -> Result<&'ctx Type>;
 }
 
 /// An `ArgScopeStack` represents the current function and template demangling

--- a/src/bin/cppfilt.rs
+++ b/src/bin/cppfilt.rs
@@ -77,9 +77,7 @@ fn main() {
     let matches = App::new("cppfilt")
         .version(crate_version!())
         .author(crate_authors!())
-        .about(
-            "A c++filt clone as an example of how to use the cpp_demangle crate!",
-        )
+        .about("A c++filt clone as an example of how to use the cpp_demangle crate!")
         .arg(
             Arg::with_name("noparams")
                 .short("p")
@@ -102,7 +100,9 @@ fn main() {
     let stderr = io::stderr();
     let mut stderr = stderr.lock();
 
-    let options = DemangleOptions { no_params: matches.is_present("noparams") };
+    let options = DemangleOptions {
+        no_params: matches.is_present("noparams"),
+    };
 
     let demangle_result = if let Some(names) = matches.values_of("mangled_names") {
         let mut input = Cursor::new(names.fold(String::new(), |mut accumulated, name| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,36 +51,29 @@ impl fmt::Display for Error {
         match *self {
             Error::UnexpectedEnd => write!(f, "mangled symbol ends abruptly"),
             Error::UnexpectedText => write!(f, "mangled symbol is not well-formed"),
-            Error::BadBackReference => {
-                write!(
-                    f,
-                    "back reference that is out-of-bounds of the substitution table"
-                )
-            }
-            Error::BadTemplateArgReference => {
-                write!(
-                    f,
-                    "reference to a template arg that is either out-of-bounds, or in a context without template args"
-                )
-            }
-            Error::BadFunctionArgReference => {
-                write!(
-                    f,
-                    "reference to a function arg that is either out-of-bounds, or in a context without function args"
-                )
-            }
-            Error::BadLeafNameReference => {
-                write!(
-                    f,
-                    "reference to a leaf name in a context where there is no current leaf name"
-                )
-            }
-            Error::Overflow => {
-                write!(
-                    f,
-                    "an overflow or underflow would occur when parsing an integer in a mangled symbol"
-                )
-            }
+            Error::BadBackReference => write!(
+                f,
+                "back reference that is out-of-bounds of the substitution table"
+            ),
+            Error::BadTemplateArgReference => write!(
+                f,
+                "reference to a template arg that is either out-of-bounds, or in a context \
+                 without template args"
+            ),
+            Error::BadFunctionArgReference => write!(
+                f,
+                "reference to a function arg that is either out-of-bounds, or in a context \
+                 without function args"
+            ),
+            Error::BadLeafNameReference => write!(
+                f,
+                "reference to a leaf name in a context where there is no current leaf name"
+            ),
+            Error::Overflow => write!(
+                f,
+                "an overflow or underflow would occur when parsing an integer in a mangled \
+                 symbol"
+            ),
             Error::TooMuchRecursion => {
                 write!(f, "encountered too much recursion when demangling symbol")
             }
@@ -97,10 +90,12 @@ impl error::Error for Error {
                 "back reference that is out-of-bounds of the substitution table"
             }
             Error::BadTemplateArgReference => {
-                "reference to a template arg that is either out-of-bounds, or in a context without template args"
+                "reference to a template arg that is either out-of-bounds, or in a context \
+                 without template args"
             }
             Error::BadFunctionArgReference => {
-                "reference to a function arg that is either out-of-bounds, or in a context without function args"
+                "reference to a function arg that is either out-of-bounds, or in a context \
+                 without function args"
             }
             Error::BadLeafNameReference => {
                 "reference to a leaf name in a context where there is no current leaf name"

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,10 @@ pub enum Error {
     /// a context without function args.
     BadFunctionArgReference,
 
+    /// Found a reference to a leaf name in a context where there is no current
+    /// leaf name.
+    BadLeafNameReference,
+
     /// An overflow or underflow would occur when parsing an integer in a
     /// mangled symbol.
     Overflow,
@@ -65,6 +69,12 @@ impl fmt::Display for Error {
                     "reference to a function arg that is either out-of-bounds, or in a context without function args"
                 )
             }
+            Error::BadLeafNameReference => {
+                write!(
+                    f,
+                    "reference to a leaf name in a context where there is no current leaf name"
+                )
+            }
             Error::Overflow => {
                 write!(
                     f,
@@ -91,6 +101,9 @@ impl error::Error for Error {
             }
             Error::BadFunctionArgReference => {
                 "reference to a function arg that is either out-of-bounds, or in a context without function args"
+            }
+            Error::BadLeafNameReference => {
+                "reference to a leaf name in a context where there is no current leaf name"
             }
             Error::Overflow => {
                 "an overflow or underflow would occur when parsing an integer in a mangled symbol"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ substitutions = {:#?}",
     ///
     /// Unlike the `ToString` implementation, this function allows options to
     /// be specified.
+    ///
     /// ```
     /// use cpp_demangle::{DemangleOptions, Symbol};
     /// use std::string::ToString;

--- a/src/subs.rs
+++ b/src/subs.rs
@@ -34,14 +34,24 @@ where
     fn demangle<'prev, 'ctx>(
         &'subs self,
         ctx: &'ctx mut ast::DemangleContext<'subs, W>,
-        stack: Option<ast::ArgScopeStack<'prev, 'subs>>,
+        scope: Option<ast::ArgScopeStack<'prev, 'subs>>,
     ) -> io::Result<()> {
         match *self {
-            Substitutable::UnscopedTemplateName(ref name) => name.demangle(ctx, stack),
-            Substitutable::Type(ref ty) => ty.demangle(ctx, stack),
-            Substitutable::TemplateTemplateParam(ref ttp) => ttp.demangle(ctx, stack),
-            Substitutable::UnresolvedType(ref ty) => ty.demangle(ctx, stack),
-            Substitutable::Prefix(ref prefix) => prefix.demangle(ctx, stack),
+            Substitutable::UnscopedTemplateName(ref name) => name.demangle(ctx, scope),
+            Substitutable::Type(ref ty) => ty.demangle(ctx, scope),
+            Substitutable::TemplateTemplateParam(ref ttp) => ttp.demangle(ctx, scope),
+            Substitutable::UnresolvedType(ref ty) => ty.demangle(ctx, scope),
+            Substitutable::Prefix(ref prefix) => prefix.demangle(ctx, scope),
+        }
+    }
+}
+
+impl<'a> ast::GetLeafName<'a> for Substitutable {
+    fn get_leaf_name(&'a self, subs: &'a SubstitutionTable) -> Option<ast::LeafName<'a>> {
+        match *self {
+            Substitutable::UnscopedTemplateName(ref name) => name.get_leaf_name(subs),
+            Substitutable::Prefix(ref prefix) => prefix.get_leaf_name(subs),
+            _ => None,
         }
     }
 }

--- a/tests/libxul.rs
+++ b/tests/libxul.rs
@@ -59,12 +59,11 @@ fn libxul_symbols_demangle() {
 
     while {
         line.clear();
-        let bytes_read = libxul_txt_file.read_until(b'\n', &mut line).expect(
-            "should read line",
-        );
+        let bytes_read = libxul_txt_file
+            .read_until(b'\n', &mut line)
+            .expect("should read line");
         bytes_read > 0
-    }
-    {
+    } {
         total += 1;
 
         // Grab the next symbol from libxul.txt.
@@ -93,12 +92,12 @@ fn libxul_symbols_demangle() {
 
                 // Finally, we are going to have `c++filt` demangle the
                 // symbol. Write the line into `c++filt`.
-                cppfilt_stdin.write_all(&line).expect(
-                    "should write line contents into c++filt",
-                );
-                cppfilt_stdin.write(b"\n").expect(
-                    "should write newline into c++filt",
-                );
+                cppfilt_stdin
+                    .write_all(&line)
+                    .expect("should write line contents into c++filt");
+                cppfilt_stdin
+                    .write(b"\n")
+                    .expect("should write newline into c++filt");
                 cppfilt_stdin.flush().expect("should flush c++filt stdin");
 
                 // Read its demangled version back out.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -132,7 +132,7 @@ demangles!(
 
 demangles!(
     _ZZN7mozilla12EMEDecryptor5FlushEvENUlvE_D4Ev,
-    "mozilla::EMEDecryptor::Flush()::{lambda()#1}::maybe in-charge destructor()"
+    "mozilla::EMEDecryptor::Flush()::{lambda()#1}::~{lambda()#1}()"
 );
 
 demangles!(
@@ -163,6 +163,34 @@ demangles!(
 demangles!(
     _ZGRL13MozLangGroups_,
     "reference temporary #0 for MozLangGroups"
+);
+
+demangles!(_ZZ3abcvEN3defD0Ev, "abc()::def::~def()");
+demangles!(
+    _ZZN13CrashReporter7OOPInitEvEN17ProxyToMainThreadD0Ev,
+    "CrashReporter::OOPInit()::ProxyToMainThread::~ProxyToMainThread()"
+);
+
+demangles!(_ZUlvE_, "{lambda()#1}");
+demangles!(_ZZ3aaavEUlvE_, "aaa()::{lambda()#1}");
+demangles!(_ZZ3aaavENUlvE_3bbbE, "aaa()::{lambda()#1}::bbb");
+demangles!(_ZN3aaaUlvE_D1Ev, "aaa::{lambda()#1}::~{lambda()#1}()");
+
+demangles!(_ZZ3aaavEN3bbbD1Ev, "aaa()::bbb::~bbb()");
+demangles!(
+    _ZZ3aaavENUlvE_D1Ev,
+    // libiberty says "aaa()::{lambda()#1}::~aaa()" but I am pretty sure that is
+    // a bug, especially given the previous demangling, which is the same but
+    // with an identifier instead of a lambda. Finally, both demangle.go and my
+    // OSX system `__cxa_demangle` agree with this destructor-of-the-lambda
+    // interpretation.
+    "aaa()::{lambda()#1}::~{lambda()#1}()"
+);
+
+demangles!(
+    multiple_nested_local_names_and_operator_call_and_a_lambda_and_a_destructor,
+    "_ZZZN7mozilla12MediaManager12GetUserMediaEP18nsPIDOMWindowInnerRKNS_3dom22MediaStreamConstraintsEP33nsIDOMGetUserMediaSuccessCallbackP31nsIDOMGetUserMediaErrorCallbackNS3_10CallerTypeEEN4$_30clERP8nsTArrayI6RefPtrINS_11MediaDeviceEEEENUlRPKcE_D1Ev",
+    "mozilla::MediaManager::GetUserMedia(nsPIDOMWindowInner*, mozilla::dom::MediaStreamConstraints const&, nsIDOMGetUserMediaSuccessCallback*, nsIDOMGetUserMediaErrorCallback*, mozilla::dom::CallerType)::$_30::operator()(nsTArray<RefPtr<mozilla::MediaDevice> >*&)::{lambda(char const*&)#1}::~{lambda(char const*&)#1}()"
 );
 
 demangles!(_ZN11InstrumentsL8gSessionE, "Instruments::gSession");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -22,18 +22,18 @@ fn assert_demangles_as(mangled: &str, expected: &str) {
         let mut last = None;
         for cmp in diff::chars(expected, &actual) {
             match (last, cmp.clone()) {
-                (Some(diff::Result::Left(_)), diff::Result::Left(_)) |
-                (Some(diff::Result::Both(..)), diff::Result::Both(..)) |
-                (Some(diff::Result::Right(_)), diff::Result::Right(_)) => {}
+                (Some(diff::Result::Left(_)), diff::Result::Left(_))
+                | (Some(diff::Result::Both(..)), diff::Result::Both(..))
+                | (Some(diff::Result::Right(_)), diff::Result::Right(_)) => {}
 
                 (_, diff::Result::Left(_)) => print!("\n-"),
                 (_, diff::Result::Both(..)) => print!("\n "),
                 (_, diff::Result::Right(_)) => print!("\n+"),
             };
             match cmp.clone() {
-                diff::Result::Left(c) |
-                diff::Result::Both(c, _) |
-                diff::Result::Right(c) => print!("{}", c),
+                diff::Result::Left(c) | diff::Result::Both(c, _) | diff::Result::Right(c) => {
+                    print!("{}", c)
+                }
             }
             last = Some(cmp);
         }
@@ -194,14 +194,21 @@ demangles!(
 );
 
 demangles!(_ZN11InstrumentsL8gSessionE, "Instruments::gSession");
-demangles!(_ZTWN2js10TlsContextE, "TLS wrapper function for js::TlsContext");
+demangles!(
+    _ZTWN2js10TlsContextE,
+    "TLS wrapper function for js::TlsContext"
+);
 
 demangles!(_Z3fooILb0EEvi, "void foo<false>(int)");
 demangles!(_Z3fooILb1EEvi, "void foo<true>(int)");
 demangles!(_Z3fooILb2EEvi, "void foo<(bool)2>(int)");
 demangles!(_Z3fooILb999999EEvi, "void foo<(bool)999999>(int)");
 demangles!(_Z3fooILbaaaaaaEEvi, "void foo<(bool)aaaaaa>(int)");
-demangles!(bool_literal_with_decimal, "_Z3fooILb999.999EEvi", "void foo<(bool)999.999>(int)");
+demangles!(
+    bool_literal_with_decimal,
+    "_Z3fooILb999.999EEvi",
+    "void foo<(bool)999.999>(int)"
+);
 demangles!(_Z3fooILbn1EEvi, "void foo<(bool)-1>(int)");
 demangles!(_Z3fooILbn0EEvi, "void foo<(bool)-0>(int)");
 
@@ -210,40 +217,74 @@ demangles!(_Z3fooILc48EEvi, "void foo<(char)48>(int)");
 demangles!(_Z3fooILc0EEvi, "void foo<(char)0>(int)");
 demangles!(_Z3fooILc999999EEvi, "void foo<(char)999999>(int)");
 demangles!(_Z3fooILcaaaaaaEEvi, "void foo<(char)aaaaaa>(int)");
-demangles!(char_literal_with_decimal, "_Z3fooILc999.999EEvi", "void foo<(char)999.999>(int)");
+demangles!(
+    char_literal_with_decimal,
+    "_Z3fooILc999.999EEvi",
+    "void foo<(char)999.999>(int)"
+);
 demangles!(_Z3fooILcn65EEvi, "void foo<(char)-65>(int)");
-demangles!(char_literal_with_negative_sign, "_Z3fooILc-65EEvi", "void foo<(char)-65>(int)");
+demangles!(
+    char_literal_with_negative_sign,
+    "_Z3fooILc-65EEvi",
+    "void foo<(char)-65>(int)"
+);
 
 demangles!(_Z3fooILd65EEvi, "void foo<(double)[65]>(int)");
 demangles!(_Z3fooILd48EEvi, "void foo<(double)[48]>(int)");
 demangles!(_Z3fooILd0EEvi, "void foo<(double)[0]>(int)");
 demangles!(_Z3fooILd999999EEvi, "void foo<(double)[999999]>(int)");
 demangles!(_Z3fooILdaaaaaaEEvi, "void foo<(double)[aaaaaa]>(int)");
-demangles!(double_literal_with_decimal, "_Z3fooILd999.999EEvi", "void foo<(double)[999.999]>(int)");
+demangles!(
+    double_literal_with_decimal,
+    "_Z3fooILd999.999EEvi",
+    "void foo<(double)[999.999]>(int)"
+);
 demangles!(_Z3fooILdn65EEvi, "void foo<(double)-[65]>(int)");
-demangles!(double_literal_with_negative_sign, "_Z3fooILd-65EEvi", "void foo<(double)[-65]>(int)");
+demangles!(
+    double_literal_with_negative_sign,
+    "_Z3fooILd-65EEvi",
+    "void foo<(double)[-65]>(int)"
+);
 
 demangles!(_Z3fooILf65EEvi, "void foo<(float)[65]>(int)");
 demangles!(_Z3fooILf48EEvi, "void foo<(float)[48]>(int)");
 demangles!(_Z3fooILf0EEvi, "void foo<(float)[0]>(int)");
 demangles!(_Z3fooILf999999EEvi, "void foo<(float)[999999]>(int)");
 demangles!(_Z3fooILfaaaaaaEEvi, "void foo<(float)[aaaaaa]>(int)");
-demangles!(float_literal_with_decimal, "_Z3fooILf999.999EEvi", "void foo<(float)[999.999]>(int)");
+demangles!(
+    float_literal_with_decimal,
+    "_Z3fooILf999.999EEvi",
+    "void foo<(float)[999.999]>(int)"
+);
 demangles!(_Z3fooILfn65EEvi, "void foo<(float)-[65]>(int)");
-demangles!(float_literal_with_negative_sign, "_Z3fooILf-65EEvi", "void foo<(float)[-65]>(int)");
+demangles!(
+    float_literal_with_negative_sign,
+    "_Z3fooILf-65EEvi",
+    "void foo<(float)[-65]>(int)"
+);
 
 demangles!(_Z3fooILin1EEvv, "void foo<-1>()");
 demangles!(_Z3fooILi0EEvv, "void foo<0>()");
 demangles!(_Z3fooILin0EEvv, "void foo<-0>()");
 demangles!(_Z3fooILi999999EEvv, "void foo<999999>()");
 demangles!(_Z3fooILiaaaaaaEEvv, "void foo<aaaaaa>()");
-demangles!(int_literal_with_decimal, "_Z3fooILi999.999EEvv", "void foo<999.999>()");
+demangles!(
+    int_literal_with_decimal,
+    "_Z3fooILi999.999EEvv",
+    "void foo<999.999>()"
+);
 
 demangles!(_Z3abcrA_l, "abc(long restrict [])");
 demangles!(_Z3abcFrA_lvE, "abc(long restrict (()) [])");
 demangles!(_Z3abcFrPA_lvE, "abc(long (* restrict()) [])");
-demangles!(_Z3abcM3defFPVPFrPivEvE, "abc(int* restrict (* volatile* (def::*)())())");
-demangles!(_Z3abcM3defFPVPFrPA_lvEvE, "abc(long (* restrict (* volatile* (def::*)())()) [])");
+demangles!(
+    _Z3abcM3defFPVPFrPivEvE,
+    "abc(int* restrict (* volatile* (def::*)())())"
+);
+demangles!(
+    _Z3abcM3defFPVPFrPA_lvEvE,
+    "abc(long (* restrict (* volatile* (def::*)())()) [])"
+);
 demangles!(_Z3abcKFA_ivE, "abc(int (() const) [])");
 demangles!(_Z3abcFFivElE, "abc(int (long)())");
 demangles!(_Z3abcFPFrPivElE, "abc(int* restrict (*(long))())");


### PR DESCRIPTION
This adds about 10% to the demangled-same-as-libiberty rate for libxul symbols:

```
Total number of libxul symbols:                       274346
Number of libxul symbols parsed:                      274319 (99.99%)
Number of libxul symbols demangled:                   274319 (99.99%)
Number of libxul symbols demangled same as libiberty: 227202 (82.82%)
```