### PR TITLE
Don't let no_params apply to nested function types

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -416,3 +416,7 @@ demangles_no_param!(
     _ZN2js9LifoAlloc21newArrayUninitializedI17OffsetAndDefIndexEEPT_m,
     "js::LifoAlloc::newArrayUninitialized<OffsetAndDefIndex>"
 );
+demangles_no_param!(
+    _Z4callIXadL_Z5helloiEEEvi,
+    "call<&hello(int)>"
+);


### PR DESCRIPTION
Sorry about this. At least there's a test now.