### PR TITLE
Handle UnnamedTypeName for Constructors and Destructors

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -289,7 +289,7 @@ pub(crate) enum LeafName<'a> {
     SourceName(&'a SourceName),
     WellKnownComponent(&'a WellKnownComponent),
     Closure(&'a ClosureTypeName),
-    // TODO: unnamed types as well?
+    UnnamedType(&'a UnnamedTypeName),
 }
 
 impl<'subs, W> DemangleAsLeaf<'subs, W> for LeafName<'subs>
@@ -304,6 +304,7 @@ where
             LeafName::SourceName(sn) => sn.demangle(ctx, None),
             LeafName::Closure(c) => c.demangle(ctx, None),
             LeafName::WellKnownComponent(wkc) => wkc.demangle_as_leaf(ctx),
+            LeafName::UnnamedType(utn) => utn.demangle_as_leaf(ctx),
         }
     }
 }
@@ -466,6 +467,10 @@ where
     // The original input string.
     input: &'a [u8],
 
+    // `Identifier`s will be placed here, so `UnnamedTypeName` can utilize and print
+    // out Constructor/Destructor used.
+    source_name: Option<String>,
+
     // What the demangled name is being written to.
     out: W,
 
@@ -520,6 +525,7 @@ where
             subs: subs,
             inner: vec![],
             input: input,
+            source_name: None,
             out: out,
             bytes_written: 0,
             last_char_written: None,
@@ -1305,6 +1311,7 @@ where
                         LeafName::SourceName(leaf) => scope.push(leaf),
                         LeafName::WellKnownComponent(leaf) => scope.push(leaf),
                         LeafName::Closure(leaf) => scope.push(leaf),
+                        LeafName::UnnamedType(leaf) => scope.push(leaf),
                     }
                 } else {
                     scope
@@ -2276,9 +2283,11 @@ impl<'a> GetLeafName<'a> for UnqualifiedName {
     fn get_leaf_name(&'a self, subs: &'a SubstitutionTable) -> Option<LeafName<'a>> {
         match *self {
             UnqualifiedName::ABITag(_)
-            | UnqualifiedName::UnnamedType(_)
-            | UnqualifiedName::Operator(_)
+            | UnqualifiedName::Operator(_) => None,
             | UnqualifiedName::CtorDtor(_) => None,
+            UnqualifiedName::UnnamedType(ref name) => {
+                Some(LeafName::UnnamedType(name))
+            },
             UnqualifiedName::ClosureType(ref closure) => closure.get_leaf_name(subs),
             UnqualifiedName::Source(ref name) | UnqualifiedName::LocalSourceName(ref name, _) => {
                 Some(LeafName::SourceName(name))
@@ -2528,7 +2537,9 @@ where
             }
         }
 
-        write!(ctx, "{}", String::from_utf8_lossy(ident))?;
+        let source_name = String::from_utf8_lossy(ident);
+        ctx.source_name = Some(source_name.to_string());
+        write!(ctx, "{}", source_name)?;
         Ok(())
     }
 }
@@ -4080,8 +4091,41 @@ where
     ) -> fmt::Result {
         log_demangle!(self, ctx, scope);
 
-        write!(ctx, "{{unnamed type {}}}", self.0.map_or(0, |n| n + 1))?;
+        write!(ctx, "{{unnamed type#{}}}", self.0.map_or(1, |n| n + 1))?;
         Ok(())
+    }
+}
+
+impl<'subs, W> DemangleAsLeaf<'subs, W> for UnnamedTypeName
+where
+    W: 'subs + fmt::Write,
+{
+    fn demangle_as_leaf<'me, 'ctx>(
+        &'me self,
+        ctx: &'ctx mut DemangleContext<'subs, W>,
+    ) -> fmt::Result {
+        log_demangle!(self, ctx, None);
+        if ctx.source_name.is_some() {
+            let source_name = ctx.source_name.clone().unwrap();
+            write!(ctx, "{}", source_name)?;
+        } else {
+            write!(ctx, "{{unnamed type#{}}}", self.0.map_or(1, |n| n + 1))?;
+        }
+        Ok(())
+    }
+}
+
+impl<'subs> ArgScope<'subs, 'subs> for UnnamedTypeName {
+    fn leaf_name(&'subs self) -> Result<LeafName<'subs>> {
+        Ok(LeafName::UnnamedType(self))
+    }
+
+    fn get_template_arg(&'subs self, _: usize) -> Result<(&'subs TemplateArg, &'subs TemplateArgs)> {
+        Err(error::Error::BadTemplateArgReference)
+    }
+
+    fn get_function_arg(&'subs self, _: usize) -> Result<&'subs Type> {
+        Err(error::Error::BadFunctionArgReference)
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -459,3 +459,7 @@ demangles_no_param!(
     _ZNK5Hello6methodEv,
     "Hello::method"
 );
+demangles!(
+    _ZZN17TestLargestRegion18TestNonRectangularEvENUt_D2Ev,
+    "TestLargestRegion::TestNonRectangular()::{unnamed type#1}::~TestNonRectangular()"
+);


### PR DESCRIPTION
So, essentially I'm trying to mimic what `binutils` does for `cxxfilt`.

What `cxxfilt` does is store the source name [before hand](https://github.com/bminor/binutils-gdb/blob/master/libiberty/cp-demangle.h#L115), then store it within the `ctor-dtor` [node](https://github.com/bminor/binutils-gdb/blob/master/libiberty/cp-demangle.c#L905). 

This is a WIP, and will be improved; I just wanted some feedback to see if this looks decent. 