### PR TITLE
Add `clone-suffix` production

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -463,3 +463,8 @@ demangles!(
     _ZZN17TestLargestRegion18TestNonRectangularEvENUt_D2Ev,
     "TestLargestRegion::TestNonRectangular()::{unnamed type#1}::~TestNonRectangular()"
 );
+demangles!(
+    clone_suffix,
+    "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.90",
+    "void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) [clone .isra.90]"
+);


### PR DESCRIPTION
This is a fix for #156.

`_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag.isra.90`

Turns into:
`void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) [clone .isra.90]`