### PR TITLE
Support extracting syntactic structure while demangling

### DIFF
--- a/src/subs.rs
+++ b/src/subs.rs
@@ -1,5 +1,6 @@
 //! Types dealing with the substitutions table.
 
+use super::DemangleWrite;
 use ast;
 use std::fmt;
 use std::iter::FromIterator;
@@ -29,7 +30,7 @@ pub enum Substitutable {
 
 impl<'subs, W> ast::Demangle<'subs, W> for Substitutable
 where
-    W: 'subs + fmt::Write,
+    W: 'subs + DemangleWrite,
 {
     fn demangle<'prev, 'ctx>(
         &'subs self,


### PR DESCRIPTION
For the Pernosco debugger we want to understand the structure of demangled C++ identifiers, e.g. so we can hide some prefixes. It makes more sense to extract this from the information cpp_demangle already has than to reparse a demangled identifier. Here's an extension to cpp_demangle that addresses this. Adding more node types would be pretty easy. This approach is lightweight in the sense that it shouldn't have any performance or code-size impact if the feature is not used.