### PR TITLE
Emit more AST markers for semantic consumers

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2445,7 +2445,8 @@ where
     ) -> fmt::Result {
         let ctx = try_begin_demangle!(self, ctx, scope);
 
-        match *self {
+        ctx.push_demangle_node(DemangleNodeType::UnqualifiedName);
+        let ret = match *self {
             UnqualifiedName::Operator(ref op_name) => {
                 write!(ctx, "operator")?;
                 op_name.demangle(ctx, scope)
@@ -2457,7 +2458,9 @@ where
             UnqualifiedName::UnnamedType(ref unnamed) => unnamed.demangle(ctx, scope),
             UnqualifiedName::ABITag(ref tagged) => tagged.demangle(ctx, scope),
             UnqualifiedName::ClosureType(ref closure) => closure.demangle(ctx, scope),
-        }
+        };
+        ctx.pop_demangle_node();
+        ret
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -4288,14 +4288,17 @@ where
     ) -> fmt::Result {
         let ctx = try_begin_demangle!(self, ctx, scope);
 
-        match *self {
+        ctx.push_demangle_node(DemangleNodeType::TemplateParam);
+        let ret = match *self {
             Decltype::Expression(ref expr) | Decltype::IdExpression(ref expr) => {
                 write!(ctx, "decltype (")?;
                 expr.demangle(ctx, scope)?;
                 write!(ctx, ")")?;
                 Ok(())
             }
-        }
+        };
+        ctx.pop_demangle_node();
+        ret
     }
 }
 
@@ -4830,13 +4833,16 @@ where
     ) -> fmt::Result {
         let ctx = try_begin_demangle!(self, ctx, scope);
 
-        if ctx.is_lambda_arg {
+        ctx.push_demangle_node(DemangleNodeType::TemplateParam);
+        let ret = if ctx.is_lambda_arg {
             // To match libiberty, template references are converted to `auto`.
             write!(ctx, "auto:{}", self.0 + 1)
         } else {
             let arg = self.resolve(scope)?;
             arg.demangle(ctx, scope)
-        }
+        };
+        ctx.pop_demangle_node();
+        ret
     }
 }
 
@@ -7038,7 +7044,10 @@ where
     ) -> fmt::Result {
         let ctx = try_begin_demangle!(self, ctx, scope);
 
-        self.0.demangle(ctx, scope)
+        ctx.push_demangle_node(DemangleNodeType::DataMemberPrefix);
+        let ret = self.0.demangle(ctx, scope);
+        ctx.pop_demangle_node();
+        ret
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,8 @@ pub enum DemangleNodeType {
     Decltype,
     /// Entering a <data-member-prefix> production
     DataMemberPrefix,
+    /// Entering a <nested-name> production
+    NestedName,
 }
 
 /// Sink for demangled text that reports syntactic structure.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,8 @@ pub enum DemangleNodeType {
     TemplatePrefix,
     /// Entering a <template-args> production
     TemplateArgs,
+    /// Entering a <unqualified-name> production
+    UnqualifiedName,
 }
 
 /// Sink for demangled text that reports syntactic structure.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,12 @@ pub enum DemangleNodeType {
     TemplateArgs,
     /// Entering a <unqualified-name> production
     UnqualifiedName,
+    /// Entering a <template-param> production
+    TemplateParam,
+    /// Entering a <decltype> production
+    Decltype,
+    /// Entering a <data-member-prefix> production
+    DataMemberPrefix,
 }
 
 /// Sink for demangled text that reports syntactic structure.


### PR DESCRIPTION
This is pretty straightforward but maybe @fitzgen wants to have a quick look.