### PR TITLE
Demangle invocation block symbols

### DIFF
--- a/examples/cppfilt.rs
+++ b/examples/cppfilt.rs
@@ -22,9 +22,12 @@ fn find_mangled(haystack: &[u8]) -> Option<usize> {
 
     for i in 0..haystack.len() - 1 {
         if haystack[i] == b'_' {
-            let next = haystack[i + 1];
-            if next == b'Z' || next == b'_' && haystack.get(i + 2) == Some(&b'Z') {
-                return Some(i);
+            match (haystack[i + 1], haystack.get(i + 2), haystack.get(i + 3), haystack.get(i + 4)) {
+                (b'Z', _, _, _)
+                | (b'_', Some(b'Z'), _, _)
+                | (b'_', Some(b'_'), Some(b'Z'), _) => return Some(i),
+                | (b'_', Some(b'_'), Some(b'_'), Some(b'Z')) => return Some(i),
+                _ => (),
             }
         }
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1299,11 +1299,20 @@ macro_rules! define_vocabulary {
 ///
 /// ```text
 /// <mangled-name> ::= _Z <encoding> [<clone-suffix>]*
+///                ::= ___Z <encoding> <block_invoke>
+///                ::= <type>
+///
+/// <block_invoke> ::= _block_invoke
+///                ::= _block_invoke<decimal-digit>+
+///                ::= _block_invoke_<decimal-digit>+
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MangledName {
     /// The encoding of the mangled symbol name.
     Encoding(Encoding, Vec<CloneSuffix>),
+
+    /// The encoding of the mangled symbol name.
+    BlockInvoke(Encoding, Option<isize>),
 
     /// A top-level type. Technically not allowed by the standard, however in
     /// practice this can happen, and is tested for by libiberty.
@@ -1327,6 +1336,23 @@ impl Parse for MangledName {
             let (encoding, tail) = Encoding::parse(ctx, subs, tail)?;
             let (clone_suffixes, tail) = zero_or_more(ctx, subs, tail)?;
             return Ok((MangledName::Encoding(encoding, clone_suffixes), tail));
+        }
+
+        if let Ok(tail) = consume(b"___Z", input).or_else(|_| consume(b"____Z", input)) {
+            let (encoding, tail) = Encoding::parse(ctx, subs, tail)?;
+            let tail = consume(b"_block_invoke", tail)?;
+
+            let tail_opt = match consume(b"_", tail) {
+                Ok(tail) => Some(parse_number(10, false, tail)?),
+                Err(_) => parse_number(10, false, tail).ok(),
+            };
+
+            let (digits, tail) = match tail_opt {
+                Some((digits, tail)) => (Some(digits), tail),
+                None => (None, tail),
+            };
+
+            return Ok((MangledName::BlockInvoke(encoding, digits), tail));
         }
 
         if let Ok(tail) = consume(b"_GLOBAL_", input) {
@@ -1362,6 +1388,11 @@ where
                 }
                 Ok(())
             },
+            MangledName::BlockInvoke(ref enc, _) => {
+                write!(ctx, "invocation function for block in ")?;
+                enc.demangle(ctx, scope)?;
+                Ok(())
+            }
             MangledName::Type(ref ty) => ty.demangle(ctx, scope),
             MangledName::GlobalCtorDtor(ref gcd) => gcd.demangle(ctx, scope),
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -506,3 +506,8 @@ demangles!(
     _ZNK1QssERKS_,
     "Q::operator<=>(Q const&) const"
 );
+// Taken from https://git.llvm.org/klaus/libcxxabi/commit/5dd173b3792e868a7ebfa699d156f24075eafc01.diff
+demangles!(
+    ___ZN19URLConnectionClient33_clientInterface_cancelConnectionEP16dispatch_queue_sU13block_pointerFvvE_block_invoke14,
+    "invocation function for block in URLConnectionClient::_clientInterface_cancelConnection(dispatch_queue_s*, void () block_pointer)"
+);


### PR DESCRIPTION
Demangles symbols like this one:

```
___ZN19URLConnectionClient33_clientInterface_cancelConnectionEP16dispatch_queue_sU13block_pointerFvvE_block_invoke14
```

- Starts with `___Z` (three `_`)
- Ends with `_block_invoke` and an optional number (required if followed by `_`)
- Cannot contain clone suffixes

See http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20130408/077728.html