### PR TITLE
Demangle the spaceship operator

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3067,7 +3067,8 @@ define_vocabulary! {
         DerefMember      (b"pt",  "->",       2),
         Call             (b"cl",  "()",       2),
         Index            (b"ix",  "[]",       2),
-        Question         (b"qu",  "?:",       3)
+        Question         (b"qu",  "?:",       3),
+        Spaceship        (b"ss",  "<=>",      2)
     }
 
     impl SimpleOperatorName {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -502,3 +502,7 @@ demangles!(
     _ZN7mozilla5xpcom16GetServiceHelperCI2NS0_18StaticModuleHelperEENS0_8ModuleIDEP8nsresult,
     "mozilla::xpcom::GetServiceHelper::StaticModuleHelper(mozilla::xpcom::ModuleID, nsresult*)"
 );
+demangles!(
+    _ZNK1QssERKS_,
+    "Q::operator<=>(Q const&) const"
+);


### PR DESCRIPTION
This adds support for mangling of operator<=>, new in C++20.