### PR TITLE
Fix warnings and clippy lints

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -73,7 +73,7 @@ use std::io::Read;
         let entry = entry?;
 
         let path = entry.path();
-        let file_name = path.file_name().ok_or(io::Error::new(
+        let file_name = path.file_name().ok_or_else(|| io::Error::new(
             io::ErrorKind::Other,
             "no file name for AFL.rs seed test case",
         ))?;

--- a/examples/cppfilt.rs
+++ b/examples/cppfilt.rs
@@ -14,7 +14,6 @@ use std::process;
 
 /// Find the index of the first (potential) occurrence of a mangled C++ symbol
 /// in the given `haystack`.
-#[allow(needless_range_loop)]
 fn find_mangled(haystack: &[u8]) -> Option<usize> {
     if haystack.is_empty() {
         return None;
@@ -34,7 +33,7 @@ fn find_mangled(haystack: &[u8]) -> Option<usize> {
 
 /// Print the given `line` to `out`, with all mangled C++ symbols replaced with
 /// their demangled form.
-fn demangle_line<W>(out: &mut W, line: &[u8], options: &DemangleOptions) -> io::Result<()>
+fn demangle_line<W>(out: &mut W, line: &[u8], options: DemangleOptions) -> io::Result<()>
 where
     W: Write,
 {
@@ -44,7 +43,7 @@ where
         write!(out, "{}", String::from_utf8_lossy(&line[..idx]))?;
 
         if let Ok((sym, tail)) = BorrowedSymbol::with_tail(&line[idx..]) {
-            let demangled = sym.demangle(options).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            let demangled = sym.demangle(&options).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
             write!(out, "{}", demangled)?;
             line = tail;
         } else {
@@ -58,7 +57,7 @@ where
 
 /// Print all the lines from the given `input` to `out`, with all mangled C++
 /// symbols replaced with their demangled form.
-fn demangle_all<R, W>(input: &mut R, out: &mut W, options: &DemangleOptions) -> io::Result<()>
+fn demangle_all<R, W>(input: &mut R, out: &mut W, options: DemangleOptions) -> io::Result<()>
 where
     R: BufRead,
     W: Write,
@@ -110,9 +109,9 @@ fn main() {
             accumulated.push_str("\n");
             accumulated
         }));
-        demangle_all(&mut input, &mut stdout, &options)
+        demangle_all(&mut input, &mut stdout, options)
     } else {
-        demangle_all(&mut stdin, &mut stdout, &options)
+        demangle_all(&mut stdin, &mut stdout, options)
     };
 
     let code = match demangle_result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,8 @@
 
 // Clippy stuff.
 #![allow(unknown_lints)]
-#![allow(inline_always)]
+#![allow(clippy::inline_always)]
+#![allow(clippy::redundant_field_names)]
 
 #![cfg_attr(all(not(feature = "std"), feature = "alloc"), no_std)]
 #![cfg_attr(all(not(feature = "std"), feature = "alloc"), feature(alloc))]
@@ -153,7 +154,7 @@ where
             if tail.is_empty() {
                 parsed
             } else {
-                return Err(Error::UnexpectedText.into());
+                return Err(Error::UnexpectedText);
             }
         };
 
@@ -196,13 +197,14 @@ substitutions = {:#?}",
     /// let demangled_again = sym.demangle(&options).unwrap();
     /// assert_eq!(demangled_again, demangled);
     /// ```
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn demangle(&self, options: &DemangleOptions) -> ::std::result::Result<String, fmt::Error> {
         let mut out = String::new();
         {
             let mut ctx = ast::DemangleContext::new(
                 &self.substitutions,
                 self.raw.as_ref(),
-                options,
+                *options,
                 &mut out,
             );
             self.parsed.demangle(&mut ctx, None)?;
@@ -213,11 +215,12 @@ substitutions = {:#?}",
 
     /// Demangle the symbol to a DemangleWrite, which lets the consumer be informed about
     /// syntactic structure.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn structured_demangle<W: DemangleWrite>(&self, out: &mut W, options: &DemangleOptions) -> fmt::Result {
         let mut ctx = ast::DemangleContext::new(
             &self.substitutions,
             self.raw.as_ref(),
-            options,
+            *options,
             out,
         );
         self.parsed.demangle(&mut ctx, None)
@@ -307,7 +310,7 @@ impl<'a, T> Symbol<&'a T>
 AST = {:#?}
 
 substitutions = {:#?}",
-            String::from_utf8_lossy(symbol.raw.as_ref()),
+            String::from_utf8_lossy(symbol.raw),
             symbol.parsed,
             symbol.substitutions
         );
@@ -327,7 +330,7 @@ where
             let mut ctx = ast::DemangleContext::new(
                 &self.substitutions,
                 self.raw.as_ref(),
-                &options,
+                options,
                 &mut out,
             );
             self.parsed.demangle(&mut ctx, None).map_err(|err| {

--- a/src/subs.rs
+++ b/src/subs.rs
@@ -11,6 +11,7 @@ use vec::Vec;
 /// table.
 #[doc(hidden)]
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum Substitutable {
     /// An `<unscoped-template-name>` production.
     UnscopedTemplateName(ast::UnscopedTemplateName),

--- a/tests/libxul.rs
+++ b/tests/libxul.rs
@@ -5,11 +5,11 @@ use std::fs;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::process;
 
-const NUMBER_OF_LIBXUL_SYMBOLS: usize = 274346;
+const NUMBER_OF_LIBXUL_SYMBOLS: usize = 274_346;
 
 // These counts should only go up!
-const NUMBER_OF_LIBXUL_SYMBOLS_THAT_PARSE: usize = 274346;
-const NUMBER_OF_LIBXUL_SYMBOLS_THAT_DEMANGLE: usize = 274346;
+const NUMBER_OF_LIBXUL_SYMBOLS_THAT_PARSE: usize = 274_346;
+const NUMBER_OF_LIBXUL_SYMBOLS_THAT_DEMANGLE: usize = 274_346;
 
 fn get_cppfilt() -> &'static str {
     if cfg!(not(target_os = "macos")) {
@@ -87,7 +87,7 @@ fn libxul_symbols_demangle() {
 
             // Demangle the symbol.
             demangled.clear();
-            if let Ok(_) = write!(&mut demangled, "{}", sym) {
+            if write!(&mut demangled, "{}", sym).is_ok() {
                 num_demangled += 1;
 
                 // Finally, we are going to have `c++filt` demangle the
@@ -96,7 +96,7 @@ fn libxul_symbols_demangle() {
                     .write_all(&line)
                     .expect("should write line contents into c++filt");
                 cppfilt_stdin
-                    .write(b"\n")
+                    .write_all(b"\n")
                     .expect("should write newline into c++filt");
                 cppfilt_stdin.flush().expect("should flush c++filt stdin");
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,7 +20,7 @@ fn assert_demangles_as(mangled: &str, expected: &str, options: Option<DemangleOp
     };
 
     if expected != actual {
-        println!("");
+        println!();
         println!("Diff:");
         println!("--- expected");
         print!("+++ actual");
@@ -43,7 +43,7 @@ fn assert_demangles_as(mangled: &str, expected: &str, options: Option<DemangleOp
             }
             last = Some(cmp);
         }
-        println!("");
+        println!();
     }
 
     assert_eq!(expected, actual);


### PR DESCRIPTION
This is more of a chore than an actual improvement. 

With RLS and rust-analyzer, it's now very common to use `clippy` by default on any project. When working on `cpp_demangle`, the warnings always threw me off. While the changes are not large improvements, they should make the code base more compatible with usual dev configs.

There's one more warning remaining, which I wasn't sure about. `afl::read_stdio_bytes` is deprecated in favor of `fuzz()`, but all the fuzz tests seem to be disabled at the moment.