### PR TITLE
Add no_return_type to DemangleOptions.

### DIFF
--- a/c_api/include/cpp_demangle.h
+++ b/c_api/include/cpp_demangle.h
@@ -8,6 +8,8 @@ extern "C" {
 struct DemangleOptions {
   // Do not display function arguments.
   bool no_params;
+  // Do not display the function return type.
+  bool no_return_type;
 };
 
 extern char *demangle(const char *buffer, struct DemangleOptions options);

--- a/c_api/test/cxxfilt.c
+++ b/c_api/test/cxxfilt.c
@@ -8,6 +8,7 @@
 static const struct option long_options[] = {
     {"help", no_argument, NULL, 'h'},
     {"no-params", no_argument, NULL, 'p'},
+    {"no-return-type", no_argument, NULL, 'r'},
     {NULL, no_argument, NULL, 0}};
 
 // Prints the help message of the program.
@@ -18,6 +19,9 @@ static void usage() {
 
   fprintf(stdout, "\
     [-p|--no-params]\t Do not display function arguments\n");
+
+  fprintf(stdout, "\
+    [-r|--no-return-type]\t Do not display function return types\n");
 
   fprintf(stdout, "]\n");
 
@@ -45,6 +49,7 @@ void demangle_name(char *mangled_name, bool no_params) {
 int main(int argc, char **argv) {
   int c = 0;
   bool no_params = false;
+  bool no_return_type = false;
 
   // This is where all the options/flags for this example should be handled.
   while ((c = getopt_long(argc, argv, "_hp", long_options, (int *)0)) != EOF) {
@@ -55,6 +60,9 @@ int main(int argc, char **argv) {
         break;
       case 'p':
         no_params = true;
+        break;
+      case 'r':
+        no_return_type = true;
         break;
     }
   }

--- a/examples/cppfilt.rs
+++ b/examples/cppfilt.rs
@@ -104,6 +104,7 @@ fn main() {
 
     let options = DemangleOptions {
         no_params: matches.is_present("noparams"),
+        no_return_type: matches.is_present("noreturntype"),
     };
 
     let demangle_result = if let Some(names) = matches.values_of("mangled_names") {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -538,10 +538,15 @@ where
     //  argument pack.
     is_template_argument_pack: bool,
 
-    // Whether to show function parameters and (if applicable) return types.
+    // Whether to show function parameters.
     // This must be set to true before calling `demangle` on `Encoding`
     // unless that call is via the toplevel call to `MangledName::demangle`.
     show_params: bool,
+
+    // Whether to show function return types.
+    // This must be set to true before calling `demangle` on `Encoding`
+    // unless that call is via the toplevel call to `MangledName::demangle`.
+    show_return_type: bool,
 
     // recursion protection.
     state: Cell<DemangleState>,
@@ -590,6 +595,7 @@ where
             is_template_prefix_in_nested_name: false,
             is_template_argument_pack: false,
             show_params: !options.no_params,
+            show_return_type: !options.no_return_type,
             state: Cell::new(DemangleState {
                 recursion_level: 0,
             }),
@@ -1483,7 +1489,7 @@ where
                 // http://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle.function-type
                 let scope = if let Some(template_args) = name.get_template_args(ctx.subs) {
                     let scope = scope.push(template_args);
-                    if ctx.show_params && !name.is_ctor_dtor_conversion(ctx.subs) {
+                    if ctx.show_return_type && !name.is_ctor_dtor_conversion(ctx.subs) {
                         fun_ty.0[0].demangle(ctx, scope)?;
                         write!(ctx, " ")?;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,8 @@ use std::fmt;
 pub struct DemangleOptions {
     /// Do not display function arguments.
     pub no_params: bool,
+    /// Do not display the function return type.
+    pub no_return_type: bool,
 }
 
 /// A `Symbol` which owns the underlying storage for the mangled name.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -80,6 +80,32 @@ macro_rules! demangles {
     };
 }
 
+macro_rules! demangles_no_param_and_no_return_type {
+    ( $mangled:ident , $demangled:expr ) => {
+        demangles_no_param_and_no_return_type!($mangled, stringify!($mangled), $demangled);
+    };
+    ( $name:ident , $mangled:expr , $demangled:expr ) => {
+        #[test]
+        fn $name() {
+            let options = DemangleOptions { no_params: true, no_return_type: true };
+            assert_demangles_as($mangled, $demangled, Some(options));
+        }
+    };
+}
+
+macro_rules! demangles_no_return_type {
+    ( $mangled:ident , $demangled:expr ) => {
+        demangles_no_return_type!($mangled, stringify!($mangled), $demangled);
+    };
+    ( $name:ident , $mangled:expr , $demangled:expr ) => {
+        #[test]
+        fn $name() {
+            let options = DemangleOptions { no_params: false, no_return_type: true };
+            assert_demangles_as($mangled, $demangled, Some(options));
+        }
+    };
+}
+
 macro_rules! demangles_no_param {
     ( $mangled:ident , $demangled:expr ) => {
         demangles_no_param!($mangled, stringify!($mangled), $demangled);
@@ -87,7 +113,7 @@ macro_rules! demangles_no_param {
     ( $name:ident , $mangled:expr , $demangled:expr ) => {
         #[test]
         fn $name() {
-            let options = DemangleOptions { no_params: true };
+            let options = DemangleOptions { no_params: true, no_return_type: false };
             assert_demangles_as($mangled, $demangled, Some(options));
         }
     };
@@ -458,18 +484,45 @@ demangles!(
     _ZNSt6vectorIN3xxx6xxxxxx15xxxxxxxxxxxxxxxESaIS2_EE12emplace_backIIS2_EEEvDpOT_,
     "void std::vector<xxx::xxxxxx::xxxxxxxxxxxxxxx, std::allocator<xxx::xxxxxx::xxxxxxxxxxxxxxx> >::emplace_back<xxx::xxxxxx::xxxxxxxxxxxxxxx>(xxx::xxxxxx::xxxxxxxxxxxxxxx&&)"
 );
-demangles_no_param!(
+demangles_no_param_and_no_return_type!(
     _ZN2js9LifoAlloc21newArrayUninitializedI17OffsetAndDefIndexEEPT_m,
     "js::LifoAlloc::newArrayUninitialized<OffsetAndDefIndex>"
 );
-demangles_no_param!(
+demangles_no_param_and_no_return_type!(
     _Z4callIXadL_Z5helloiEEEvi,
     "call<&hello(int)>"
 );
-demangles_no_param!(
+demangles_no_param_and_no_return_type!(
     _ZNK5Hello6methodEv,
     "Hello::method"
 );
+
+demangles_no_return_type!(
+    _ZL15draw_quad_spansIjEviPN4glsl11vec2_scalarEtPDv16_fR7TextureiS6_RK8ClipRect,
+    "draw_quad_spans<unsigned int>(int, glsl::vec2_scalar*, unsigned short, float __vector(16)*, Texture&, int, Texture&, ClipRect const&)"
+);
+
+demangles_no_return_type!(
+    _ZL13draw_elementsItEviiR6BuffermR11VertexArrayR7TextureiS5_,
+    "draw_elements<unsigned short>(int, int, Buffer&, unsigned long, VertexArray&, Texture&, int, Texture&)"
+);
+
+demangles_no_return_type!(
+    _ZL12check_depth8ILi515ELb0EEitPtRDv8_s,
+    "check_depth8<515, false>(unsigned short, unsigned short*, short __vector(8)&)"
+);
+
+demangles_no_return_type!(
+    _ZN7mozilla6detail23RunnableMethodArgumentsIJNS_2wr10WrWindowIdEbEE5applyINS2_12RenderThreadEMS6_FvS3_bEEEDTcl9applyImplfp_fp0_dtdefpT10mArgumentstlNSt3__116integer_sequenceImJLm0ELm1EEEEEEEPT_T0_,
+    "mozilla::detail::RunnableMethodArguments<mozilla::wr::WrWindowId, bool>::apply<mozilla::wr::RenderThread, void (mozilla::wr::RenderThread::*)(mozilla::wr::WrWindowId, bool)>(mozilla::wr::RenderThread*, void (mozilla::wr::RenderThread::*)(mozilla::wr::WrWindowId, bool))"
+);
+
+demangles_no_param!(
+    _ZN7mozilla6detail23RunnableMethodArgumentsIJNS_2wr10WrWindowIdEbEE5applyINS2_12RonderThroudEMS6_FvS3_bEEEDTcl9applyImplfp_fp0_dtdefpT10mArgumentstlNSt3__116integer_sequenceImJLm0ELm1EEEEEEEPT_T0_,
+    "decltype ((applyImpl)({parm#1}, {parm#2}, (*this).mArguments, std::__1::integer_sequence<unsigned long, (unsigned long)0, (unsigned long)1>{})) mozilla::detail::RunnableMethodArguments<mozilla::wr::WrWindowId, bool>::apply<mozilla::wr::RonderThroud, void (mozilla::wr::RonderThroud::*)(mozilla::wr::WrWindowId, bool)>"
+);
+
+
 demangles!(
     _ZZN17TestLargestRegion18TestNonRectangularEvENUt_D2Ev,
     "TestLargestRegion::TestNonRectangular()::{unnamed type#1}::~TestNonRectangular()"


### PR DESCRIPTION
Fixes #201.

I could use some feedback on the naming; I flipped back and forth between `no_return`, `no_return_type` and `no_return_types` and then settled on `no_return_type`.