### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ declarations can pair up definitions in one unit with references in another.
 Almost all platforms other than Microsoft Windows follow the
 [Itanium C++ ABI][itanium]'s rules for this.
 
-[itanium]: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle
+[itanium]: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
 
 For example, suppose a C++ compilation unit has the definition:
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1488,7 +1488,7 @@ where
                 // whether this is a template.
                 //
                 // For the details, see
-                // http://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle.function-type
+                // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle.function-type
                 let scope = if let Some(template_args) = name.get_template_args(ctx.subs) {
                     let scope = scope.push(template_args);
                     if ctx.show_return_type && !name.is_ctor_dtor_conversion(ctx.subs) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! another.  Almost all platforms other than Microsoft Windows follow the
 //! [Itanium C++ ABI][itanium]'s rules for this.
 //!
-//! [itanium]: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle
+//! [itanium]: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
 //!
 //! For example, suppose a C++ compilation unit has the definition:
 //!


### PR DESCRIPTION
Missed a link in #226. Also change links to use #mangling rather than #mangle. This was switched in #75 but as far as I can tell the original is correct.