### PR TITLE
Introduce DemangleOptions::simplify_template_parameters()

### DIFF
--- a/examples/cppfilt.rs
+++ b/examples/cppfilt.rs
@@ -101,6 +101,11 @@ fn main() {
                 .help("Do not display function arguments"),
         )
         .arg(
+            Arg::with_name("hide-expression-literal-types")
+                .long("hide-expression-literal-types")
+                .help("Hide types in template parameter expression literals"),
+        )
+        .arg(
             Arg::with_name("mangled_names")
                 .multiple(true)
                 .value_delimiter(" "),
@@ -119,6 +124,9 @@ fn main() {
     let mut options = DemangleOptions::new();
     if matches.is_present("noparams") {
         options = options.no_params();
+    }
+    if matches.is_present("hide-expression-literal-types") {
+        options = options.hide_expression_literal_types();
     }
     if matches.is_present("noreturntype") {
         options = options.no_return_type();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ impl ParseOptions {
 pub struct DemangleOptions {
     no_params: bool,
     no_return_type: bool,
+    hide_expression_literal_types: bool,
     recursion_limit: Option<NonZeroU32>,
 }
 
@@ -125,6 +126,15 @@ impl DemangleOptions {
     /// Do not display the function return type.
     pub fn no_return_type(mut self) -> Self {
         self.no_return_type = true;
+        self
+    }
+
+    /// Hide type annotations in template value parameters.
+    /// These are not needed to distinguish template instances
+    /// so this can make it easier to match user-provided
+    /// template instance names.
+    pub fn hide_expression_literal_types(mut self) -> Self {
+        self.hide_expression_literal_types = true;
         self
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -93,6 +93,19 @@ macro_rules! demangles_no_param_and_no_return_type {
     };
 }
 
+macro_rules! demangles_simplify_template_parameters {
+    ( $mangled:ident , $demangled:expr ) => {
+        demangles_simplify_template_parameters!($mangled, stringify!($mangled), $demangled);
+    };
+    ( $name:ident , $mangled:expr , $demangled:expr ) => {
+        #[test]
+        fn $name() {
+            let options = DemangleOptions::new().hide_expression_literal_types();
+            assert_demangles_as($mangled, $demangled, Some(options));
+        }
+    };
+}
+
 macro_rules! demangles_no_return_type {
     ( $mangled:ident , $demangled:expr ) => {
         demangles_no_return_type!($mangled, stringify!($mangled), $demangled);
@@ -576,4 +589,9 @@ demangles!(
 demangles!(
     _ZNKSt6__ndk112basic_stringIDuNS_11char_traitsIDuEENS_9allocatorIDuEEE5c_strEv,
     "std::__ndk1::basic_string<char8_t, std::__ndk1::char_traits<char8_t>, std::__ndk1::allocator<char8_t> >::c_str() const"
+);
+
+demangles_simplify_template_parameters!(
+    _ZN11SmiTagging2ILs4EE13kSmiShiftSizeE,
+    "SmiTagging2<4>::kSmiShiftSize"
 );


### PR DESCRIPTION
In a debugger, users may input identifiers containing template parameter values and expect some aspects of the identifer (e.g. the exact type of numeric parameters) to be inferred. For example, given `template <short N> struct X<N>`, the debugger should accept `X<3>` and not just `X<(short)3>`. A debugger can make this work by canonicalizing incoming identifiers containing template parameter values into this simplified form. (gdb does this canonicalization and Pernosco will need to do it too.) When these identifiers are being produced via cpp_demangle, it is more efficient and more reliable to have cpp_demangle itself produce this simplified form.