### PR TITLE
Fix no std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
     - name: Build
       run: cargo build --verbose --no-default-features --features alloc
     - name: Run tests
@@ -41,10 +37,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
     - name: Build
       run: cargo build --verbose --release --no-default-features --features alloc
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ name = "cpp_demangle"
 readme = "./README.md"
 repository = "https://github.com/gimli-rs/cpp_demangle"
 version = "0.3.5"
+edition = "2018"
 
 [badges]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,17 +38,15 @@ diff = "0.1.11"
 # Default features.
 default = ["std"]
 
-# Build using the `std` library. Disabling this and enabling the `alloc` feature
-# enables `no_std` support.
-std = []
+# Build using the `std` library. Disabling this enables `no_std` support.
+std = ["alloc"]
 
-# Use collections from the `alloc` crate rather than from `std`. Combined with
-# disabling `std`, this enables `no_std` support.
+# Use collections from the `alloc` crate rather than from `std`.
 alloc = []
 
 # Enable copious amounts of logging. This is for internal use only, and is only
 # useful for hacking on `cpp_demangle` itself.
-logging = []
+logging = ["std"]
 
 # Run all libiberty tests, even the ones that are known not to pass yet. This is
 # for internal use only.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,9 +1,12 @@
 //! Abstract syntax tree types for mangled symbols.
 
 use super::{DemangleNodeType, DemangleOptions, DemangleWrite, ParseOptions};
-use boxed::Box;
-use error::{self, Result};
-use index_str::IndexStr;
+use crate::boxed::Box;
+use crate::error::{self, Result};
+use crate::index_str::IndexStr;
+use crate::string::String;
+use crate::subs::{Substitutable, SubstitutionTable};
+use crate::vec::Vec;
 use std::cell::Cell;
 #[cfg(feature = "logging")]
 use std::cell::RefCell;
@@ -12,9 +15,6 @@ use std::hash::{Hash, Hasher};
 use std::mem;
 use std::ops;
 use std::ptr;
-use string::String;
-use subs::{Substitutable, SubstitutionTable};
-use vec::Vec;
 
 struct AutoLogParse;
 
@@ -7803,13 +7803,13 @@ mod tests {
         WellKnownComponent,
     };
 
-    use boxed::Box;
-    use error::Error;
-    use index_str::IndexStr;
+    use crate::boxed::Box;
+    use crate::error::Error;
+    use crate::index_str::IndexStr;
+    use crate::string::String;
+    use crate::subs::{Substitutable, SubstitutionTable};
     use std::fmt::Debug;
     use std::iter::FromIterator;
-    use string::String;
-    use subs::{Substitutable, SubstitutionTable};
 
     fn assert_parse_ok<P, S1, S2, I1, I2>(
         production: &'static str,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,20 +1,21 @@
 //! Abstract syntax tree types for mangled symbols.
 
 use super::{DemangleNodeType, DemangleOptions, DemangleWrite, ParseOptions};
-use crate::boxed::Box;
 use crate::error::{self, Result};
 use crate::index_str::IndexStr;
-use crate::string::String;
 use crate::subs::{Substitutable, SubstitutionTable};
-use crate::vec::Vec;
-use std::cell::Cell;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cell::Cell;
 #[cfg(feature = "logging")]
-use std::cell::RefCell;
-use std::fmt::{self, Write};
-use std::hash::{Hash, Hasher};
-use std::mem;
-use std::ops;
-use std::ptr;
+use core::cell::RefCell;
+use core::fmt::{self, Write};
+use core::hash::{Hash, Hasher};
+use core::mem;
+use core::ops;
+use core::ptr;
+use core::str;
 
 struct AutoLogParse;
 
@@ -454,13 +455,13 @@ struct AutoParseDemangle<'a, 'b, W: 'a + DemangleWrite>(&'b mut DemangleContext<
 
 impl<'a, 'b, W: 'a + DemangleWrite> AutoParseDemangle<'a, 'b, W> {
     #[inline]
-    fn new(ctx: &'b mut DemangleContext<'a, W>) -> std::result::Result<Self, fmt::Error> {
+    fn new(ctx: &'b mut DemangleContext<'a, W>) -> core::result::Result<Self, fmt::Error> {
         ctx.enter_recursion()?;
         Ok(AutoParseDemangle(ctx))
     }
 }
 
-impl<'a, 'b, W: 'a + DemangleWrite> std::ops::Deref for AutoParseDemangle<'a, 'b, W> {
+impl<'a, 'b, W: 'a + DemangleWrite> ops::Deref for AutoParseDemangle<'a, 'b, W> {
     type Target = DemangleContext<'a, W>;
 
     fn deref(&self) -> &Self::Target {
@@ -468,7 +469,7 @@ impl<'a, 'b, W: 'a + DemangleWrite> std::ops::Deref for AutoParseDemangle<'a, 'b
     }
 }
 
-impl<'a, 'b, W: 'a + DemangleWrite> std::ops::DerefMut for AutoParseDemangle<'a, 'b, W> {
+impl<'a, 'b, W: 'a + DemangleWrite> ops::DerefMut for AutoParseDemangle<'a, 'b, W> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }
@@ -718,7 +719,7 @@ where
 
     fn set_source_name(&mut self, start: usize, end: usize) {
         let ident = &self.input[start..end];
-        self.source_name = std::str::from_utf8(ident).ok();
+        self.source_name = str::from_utf8(ident).ok();
     }
 
     fn push_demangle_node(&mut self, t: DemangleNodeType) {
@@ -4943,7 +4944,7 @@ impl TemplateParam {
     fn resolve<'subs, 'prev>(
         &'subs self,
         scope: Option<ArgScopeStack<'prev, 'subs>>,
-    ) -> ::std::result::Result<&'subs TemplateArg, fmt::Error> {
+    ) -> ::core::result::Result<&'subs TemplateArg, fmt::Error> {
         scope
             .get_template_arg(self.0)
             .map_err(|e| {
@@ -6664,7 +6665,7 @@ where
             } else {
                 start
             };
-            let s = ::std::str::from_utf8(&ctx.input[start..end]).map_err(|e| {
+            let s = str::from_utf8(&ctx.input[start..end]).map_err(|e| {
                 log!("Error writing literal: {}", e);
                 fmt::Error
             })?;
@@ -6718,7 +6719,7 @@ where
                     write!(ctx, "[")?;
                     start
                 };
-                let s = ::std::str::from_utf8(&ctx.input[start..end]).map_err(|e| {
+                let s = str::from_utf8(&ctx.input[start..end]).map_err(|e| {
                     log!("Error writing literal: {}", e);
                     fmt::Error
                 })?;
@@ -7775,7 +7776,7 @@ fn parse_number(base: u32, allow_signed: bool, mut input: IndexStr) -> Result<(i
     let head = unsafe {
         // Safe because we know we only have valid numeric chars in this
         // slice, which are valid UTF-8.
-        ::std::str::from_utf8_unchecked(head)
+        str::from_utf8_unchecked(head)
     };
 
     let mut number = isize::from_str_radix(head, base).map_err(|_| error::Error::Overflow)?;
@@ -7803,13 +7804,13 @@ mod tests {
         WellKnownComponent,
     };
 
-    use crate::boxed::Box;
     use crate::error::Error;
     use crate::index_str::IndexStr;
-    use crate::string::String;
     use crate::subs::{Substitutable, SubstitutionTable};
-    use std::fmt::Debug;
-    use std::iter::FromIterator;
+    use alloc::boxed::Box;
+    use alloc::string::String;
+    use core::fmt::Debug;
+    use core::iter::FromIterator;
 
     fn assert_parse_ok<P, S1, S2, I1, I2>(
         production: &'static str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 //! Custom `Error` and `Result` types for the `cpp_demangle` crate.
 
+use core::fmt;
 #[cfg(feature = "std")]
 use std::error;
-use std::fmt;
 
 /// Errors that can occur while demangling a symbol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -43,9 +43,8 @@ pub enum Error {
 
 #[test]
 fn size_of_error() {
-    use std::mem;
     assert_eq!(
-        mem::size_of::<Error>(),
+        core::mem::size_of::<Error>(),
         1,
         "We should keep the size of our Error type in check"
     );
@@ -122,4 +121,4 @@ impl error::Error for Error {
 }
 
 /// A demangling result of `T` or a `cpp_demangle::error::Error`.
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = ::core::result::Result<T, Error>;

--- a/src/index_str.rs
+++ b/src/index_str.rs
@@ -1,9 +1,9 @@
 //! Provides the `IndexStr` type to keep track of a substring's index into its
 //! original string is.
 
+use crate::string::String;
 use std::fmt;
 use std::ops::{Range, RangeFrom, RangeTo};
-use string::String;
 
 /// The `IndexStr` type allows us to take substrings from an original input and
 /// keep track of what index the substring is at in the original input.

--- a/src/index_str.rs
+++ b/src/index_str.rs
@@ -1,9 +1,9 @@
 //! Provides the `IndexStr` type to keep track of a substring's index into its
 //! original string is.
 
-use crate::string::String;
-use std::fmt;
-use std::ops::{Range, RangeFrom, RangeTo};
+use alloc::string::String;
+use core::fmt;
+use core::ops::{Range, RangeFrom, RangeTo};
 
 /// The `IndexStr` type allows us to take substrings from an original input and
 /// keep track of what index the substring is at in the original input.

--- a/src/subs.rs
+++ b/src/subs.rs
@@ -1,11 +1,11 @@
 //! Types dealing with the substitutions table.
 
 use super::DemangleWrite;
-use ast;
+use crate::ast;
+use crate::vec::Vec;
 use std::fmt;
 use std::iter::FromIterator;
 use std::ops::Deref;
-use vec::Vec;
 
 /// An enumeration of all of the types that can end up in the substitution
 /// table.

--- a/src/subs.rs
+++ b/src/subs.rs
@@ -2,10 +2,10 @@
 
 use super::DemangleWrite;
 use crate::ast;
-use crate::vec::Vec;
-use std::fmt;
-use std::iter::FromIterator;
-use std::ops::Deref;
+use alloc::vec::Vec;
+use core::fmt;
+use core::iter::FromIterator;
+use core::ops::Deref;
 
 /// An enumeration of all of the types that can end up in the substitution
 /// table.


### PR DESCRIPTION
Fix `#![no_std]` build and make the crate use edition 2018.

This pushes the MSRV to 1.36, but I could not any clue of the current or the crate's policy about it.

I kept the `alloc` feature (which is required when `std` is disabled) not to break current builds, and also to allow supporting no_alloc in the future.