### PR TITLE
Update CI workflows to use Ubuntu 22.04 instead of Ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   debug:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Build
@@ -16,7 +16,7 @@ jobs:
       run: cargo test --verbose
 
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Build
@@ -25,7 +25,7 @@ jobs:
       run: cargo test --verbose --release
 
   debug-nostd:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Build
@@ -34,7 +34,7 @@ jobs:
       run: cargo test --verbose --no-default-features --features alloc
 
   release-nostd:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Build
@@ -43,7 +43,7 @@ jobs:
       run: cargo test --verbose --release --no-default-features --features alloc
 
   c_api:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Run c_api test


### PR DESCRIPTION
The Ubuntu 18.04 GitHub Actions runner image has been deprecated on 2022-08-08 and will be removed on 2023-04-01 (which is less than a month away). For more information see <https://github.com/actions/runner-images/issues/6002>.