### PR TITLE
Reorder parsing of type qualifiers to match the spec.

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -610,3 +610,14 @@ demangles!(
     _ZN7mozilla10extensions7AtomSet3GetIXadsoPKcL_ZNS0_16WILDCARD_SCHEMESEEEEEE8nsresultR6RefPtrIS1_E,
     "nsresult mozilla::extensions::AtomSet::Get<&(mozilla::extensions::WILDCARD_SCHEMES.<char const* at offset 0>)>(RefPtr<mozilla::extensions::AtomSet>&)"
 );
+
+// This symbol previously ran into some mutual recursion and unbounded growth of the substitution table.
+// See <https://github.com/gimli-rs/cpp_demangle/issues/277> and <https://github.com/getsentry/symbolic/issues/477>
+#[test]
+fn test_pathological_recursion() {
+    let s = "_ZUlzjjlZZL1zStUlSt7j_Z3kjIIjIjL1vfIIEEEjzjjfjzSt7j_Z3kjIIjfjzL4t3kjIIjfjtUlSt7j_Z3kjIIjIjL1vfIIEEEjzjjfjzSt7j_Z3kjIIjfjzL4t3kjIIjfjzL4t7IjIjjzjjzSt7j_Z3kjIIjfjzStfjzSt7j_ZA3kjIIjIjL1vfIIEEEjzjjfjzSt7j_Z3kjIIjIjL1vfIIEEEjzjjfjzSt7j_Z3kjIIjfjzL4t3kjIIjzL4t7IjIjjzjjzSt7j_Z3kjIIjfjzStfjzSt7j_ZA3kjIIjIjL1vfIIEEEjzjjfjzSt7j_Z3kjIIjIjL1vfIIEEEjzjjfjzSt7j_Z3kjIIjfjzL4t3kjIIjfjzL4t7IjIjL1vfIIEEEjzjjSI";
+    let parse_options = cpp_demangle::ParseOptions::default().recursion_limit(160); // default is 96
+    if let Ok(sym) = cpp_demangle::Symbol::new_with_options(s, &parse_options) {
+        panic!("Unexpectedly parsed '{}' as '{}'", s, sym);
+    }
+}


### PR DESCRIPTION
The spec says that the `qualified-type` production (within `type`) is parsed second only to the `builtin-type` production. The `qualified-type` production is ambiguous with later productions (in particular with the "Ul" inside `class-enum-type`) so the order does matter. This reorders things for "Ul" and brings along the other parts of the `qualified-type` production.

To preserve the existing behavior for `function-type`, rather than attempt to pass down a leading `CV-qualifiers` we simply skip them if the tail remaining indicates a `function-type` production is imminent.

This is the root cause of @Swatinem's issue, though perhaps some defense in depth that limits runaway growth of substitution tables is still wise.