### PR TITLE
Support C23 _FloatN, _FloatNx, _BitInt(N), and C++23 std::bfloat16_t

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,9 +1,8 @@
 use cpp_demangle::Symbol;
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
-
     let mangled = b"_ZN5space3fooEibc";
-    
+
     let sym = Symbol::new(&mangled[..])?;
     let demangled = sym.to_string();
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -4129,7 +4129,11 @@ impl Parse for ParametricBuiltinType {
             b'B' | b'U' => true,
             _ => return Err(error::Error::UnexpectedText),
         };
-        if input.next_or(error::Error::UnexpectedEnd)?.0.is_ascii_digit() {
+        if input
+            .next_or(error::Error::UnexpectedEnd)?
+            .0
+            .is_ascii_digit()
+        {
             let (bit_size, input) = parse_number(10, false, input)?;
             if ch == b'F' {
                 if let Ok(input) = consume(b"x", input) {
@@ -4188,7 +4192,6 @@ where
         }
     }
 }
-
 
 /// The `<builtin-type>` production.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -8096,14 +8099,14 @@ mod tests {
         ClosureTypeName, CtorDtorName, CvQualifiers, DataMemberPrefix, Decltype, DestructorName,
         Discriminator, Encoding, ExceptionSpec, ExprPrimary, Expression, FunctionParam,
         FunctionType, GlobalCtorDtor, Identifier, Initializer, LambdaSig, LocalName, MangledName,
-        MemberName, Name, NestedName, NonSubstitution, Number, NvOffset, OperatorName, Parse,
-        ParseContext, PointerToMemberType, Prefix, PrefixHandle, RefQualifier, ResourceName, SeqId,
-        SimpleId, SimpleOperatorName, SourceName, SpecialName, StandardBuiltinType, SubobjectExpr,
-        Substitution, TaggedName, TemplateArg, TemplateArgs, TemplateParam, TemplateTemplateParam,
-        TemplateTemplateParamHandle, Type, TypeHandle, UnnamedTypeName, UnqualifiedName,
-        UnresolvedName, UnresolvedQualifierLevel, UnresolvedType, UnresolvedTypeHandle,
-        UnscopedName, UnscopedTemplateName, UnscopedTemplateNameHandle, VOffset, VectorType,
-        WellKnownComponent, ParametricBuiltinType,
+        MemberName, Name, NestedName, NonSubstitution, Number, NvOffset, OperatorName,
+        ParametricBuiltinType, Parse, ParseContext, PointerToMemberType, Prefix, PrefixHandle,
+        RefQualifier, ResourceName, SeqId, SimpleId, SimpleOperatorName, SourceName, SpecialName,
+        StandardBuiltinType, SubobjectExpr, Substitution, TaggedName, TemplateArg, TemplateArgs,
+        TemplateParam, TemplateTemplateParam, TemplateTemplateParamHandle, Type, TypeHandle,
+        UnnamedTypeName, UnqualifiedName, UnresolvedName, UnresolvedQualifierLevel, UnresolvedType,
+        UnresolvedTypeHandle, UnscopedName, UnscopedTemplateName, UnscopedTemplateNameHandle,
+        VOffset, VectorType, WellKnownComponent,
     };
 
     use crate::error::Error;

--- a/src/index_str.rs
+++ b/src/index_str.rs
@@ -64,7 +64,7 @@ impl<'a> IndexStr<'a> {
         (self.range_to(..idx), self.range_from(idx..))
     }
 
-    /// The same as `split_at`, but returns a `Result` rather than panicking
+    /// The same as `split_at`, but returns an `Option` rather than panicking
     /// when the index is out of bounds.
     #[inline]
     pub fn try_split_at(&self, idx: usize) -> Option<(IndexStr<'a>, IndexStr<'a>)> {


### PR DESCRIPTION
These productions from https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling-builtin:
```
  <builtin-type> ::= [...]
                 ::= DF <number> _ # ISO/IEC TS 18661 binary floating point type _FloatN (N bits), C++23 std::floatN_t
                 ::= DF <number> x # IEEE extended precision formats, C23 _FloatNx (N bits)
                 ::= DF16b # C++23 std::bfloat16_t
                 ::= DB <number> _        # C23 signed _BitInt(N)
                 ::= DB <instantiation-dependent expression> _ # C23 signed _BitInt(N)
                 ::= DU <number> _        # C23 unsigned _BitInt(N)
                 ::= DU <instantiation-dependent expression> _ # C23 unsigned _BitInt(N)
```

(I've seen `DB8_` in the wild, everything else is just based on the 8 lines above.)