### PR TITLE
Don’t forward demangling errors in Display impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,10 +448,11 @@ where
                 options,
                 &mut out,
             );
-            self.parsed.demangle(&mut ctx, None).map_err(|err| {
+            if let Err(err) = self.parsed.demangle(&mut ctx, None) {
                 log!("Demangling error: {:#?}", err);
-                fmt::Error
-            })?;
+                write!(f, "<Demangling failed>")?;
+                return Ok(());
+            }
         }
         write!(f, "{}", &out)
     }


### PR DESCRIPTION
In the `Display` implementation of `Symbol` the potential error after demangling is turned into  a `std::fmt::Error`. 

I’d like to propose to not do that, as this will lead to panics in many cases (even just a simple `format!("{my_symbol}")`. This PR changes the `Display::fmt` implementation to output `"<Demangling failed>"` in case where the demanging failed, avoiding the panic scenario.