### PR TITLE
Allow for filtering of clone suffixes

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1610,12 +1610,18 @@ where
         scope: Option<ArgScopeStack<'prev, 'subs>>,
     ) -> fmt::Result {
         let ctx = try_begin_demangle!(self, ctx, scope);
+
+        ctx.push_demangle_node(DemangleNodeType::CloneSuffix);
+
         write!(ctx, " [clone")?;
         self.0.demangle(ctx, scope)?;
         for nonnegative in &self.1 {
             write!(ctx, ".{}", nonnegative)?;
         }
         write!(ctx, "]")?;
+
+        ctx.pop_demangle_node();
+
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,6 +336,8 @@ pub enum DemangleNodeType {
     NestedName,
     /// Entering a <special-name> production that is a vtable.
     VirtualTable,
+    /// Entering a <clone-suffix> production.
+    CloneSuffix,
     /// Additional values may be added in the future. Use a
     /// _ pattern for compatibility.
     __NonExhaustive,


### PR DESCRIPTION
One potential solution to https://github.com/gimli-rs/cpp_demangle/issues/311. This allows filtering of clone suffixes by introducing a new demangle node type.