### PR TITLE
Add deferred real-world parse probes

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -10160,9 +10160,8 @@ mod tests {
     fn parse_realworld_pcg_binarycompare_invoke_full_mangled_name_probe() {
         let mut subs = SubstitutionTable::new();
         let ctx = ParseContext::new(Default::default());
-        let input = IndexStr::new(
-            b"_ZN16PCGSelectGrammarL13BinaryCompareIdEMUlRKdS3_E_8__invokeES3_S3_",
-        );
+        let input =
+            IndexStr::new(b"_ZN16PCGSelectGrammarL13BinaryCompareIdEMUlRKdS3_E_8__invokeES3_S3_");
 
         match MangledName::parse(&ctx, &mut subs, input) {
             Ok((_name, tail)) => assert!(
@@ -10181,9 +10180,8 @@ mod tests {
     fn parse_realworld_pcg_binarycompare_name_and_bare_probe() {
         let mut subs = SubstitutionTable::new();
         let ctx = ParseContext::new(Default::default());
-        let input = IndexStr::new(
-            b"N16PCGSelectGrammarL13BinaryCompareIdEMUlRKdS3_E_8__invokeES3_S3_",
-        );
+        let input =
+            IndexStr::new(b"N16PCGSelectGrammarL13BinaryCompareIdEMUlRKdS3_E_8__invokeES3_S3_");
 
         let (_name, tail) = Name::parse(&ctx, &mut subs, input).expect("name parse");
         match BareFunctionType::parse(&ctx, &mut subs, tail) {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -10157,6 +10157,46 @@ mod tests {
     }
 
     #[test]
+    fn parse_realworld_pcg_binarycompare_invoke_full_mangled_name_probe() {
+        let mut subs = SubstitutionTable::new();
+        let ctx = ParseContext::new(Default::default());
+        let input = IndexStr::new(
+            b"_ZN16PCGSelectGrammarL13BinaryCompareIdEMUlRKdS3_E_8__invokeES3_S3_",
+        );
+
+        match MangledName::parse(&ctx, &mut subs, input) {
+            Ok((_name, tail)) => assert!(
+                tail.is_empty(),
+                "pcg binarycompare invoke full parse left tail: {:?}",
+                String::from_utf8_lossy(tail.as_ref())
+            ),
+            Err(err) => panic!(
+                "failed pcg binarycompare invoke full mangled name: {:?}",
+                err
+            ),
+        }
+    }
+
+    #[test]
+    fn parse_realworld_pcg_binarycompare_name_and_bare_probe() {
+        let mut subs = SubstitutionTable::new();
+        let ctx = ParseContext::new(Default::default());
+        let input = IndexStr::new(
+            b"N16PCGSelectGrammarL13BinaryCompareIdEMUlRKdS3_E_8__invokeES3_S3_",
+        );
+
+        let (_name, tail) = Name::parse(&ctx, &mut subs, input).expect("name parse");
+        match BareFunctionType::parse(&ctx, &mut subs, tail) {
+            Ok((_ty, tail)) => assert!(
+                tail.is_empty(),
+                "pcg binarycompare bare full parse left tail: {:?}",
+                String::from_utf8_lossy(tail.as_ref())
+            ),
+            Err(err) => panic!("failed pcg binarycompare bare function parse: {:?}", err),
+        }
+    }
+
+    #[test]
     fn parse_template_arg() {
         assert_parse!(TemplateArg {
             with subs [


### PR DESCRIPTION
## Summary
- add deferred real-world parse/demangle probes collected during branch splitting

## Motivation and Context
These probes are intentionally separated because they rely on the combined behavior introduced by all three C++20 split PRs:
- PR #314: [level-aware template parameter resolution + requires-clause rendering](https://github.com/gimli-rs/cpp_demangle/pull/314)
- PR #315: [extended template-parameter qualifier forms](https://github.com/gimli-rs/cpp_demangle/pull/315)
- PR #316: [local-source template handling and nested-name normalization](https://github.com/gimli-rs/cpp_demangle/pull/316)

In other words, this test slice is expected to be meaningful only once the combined behavior from #314 + #315 + #316 is present.

## Scope
- test/probe additions only
- no parser or demangler logic changes