### PR TITLE
Ensure new type is `repr(transparent)`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -911,6 +911,7 @@ where
 macro_rules! reference_newtype {
     ( $newtype_name:ident , $oldtype:ty ) => {
         #[derive(Debug)]
+        #[repr(transparent)]
         struct $newtype_name($oldtype);
 
         impl $newtype_name {


### PR DESCRIPTION
The immediately following code performs a cast from the new type to the old type, which `repr(transparent)` guarantees the safety of. I'm not convinced this is _guaranteed_ to be safe with the default `repr(Rust)`.